### PR TITLE
Add zlib import to example vue.config.js (Fixes #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ vue add compression
 `vue-cli-plugin-compression` default configuration in `vue.config.js`:
 
 ```js
+const zlib = require("zlib");
 module.exports = {
   pluginOptions: {
     compression:{


### PR DESCRIPTION
This PR updates README.md to add a line defining `zlib`. 